### PR TITLE
favorites order fix

### DIFF
--- a/src/app/database.js
+++ b/src/app/database.js
@@ -132,6 +132,7 @@ var Database = {
     },
 
     // format: {page: page, keywords: title}
+    // format: {page: page, keywords: title}
     getBookmarks: function (data) {
         var page = data.page - 1;
         var byPage = 50;
@@ -145,16 +146,14 @@ var Database = {
         return promisifyDb(db.bookmarks.find(query).skip(offset).limit(byPage));
     },
 
-    getAllBookmarks: function () {
-        return promisifyDb(db.bookmarks.find({}))
-            .then(function (data) {
-                var bookmarks = [];
-                if (data) {
-                    bookmarks = extractIds(data);
-                }
+    getAllBookmarks: function (data) {
+        var query = {};
 
-                return bookmarks;
-            });
+        if (data !== undefined && data.type) {
+            query.type = data.type;
+        }
+
+        return promisifyDb(db.bookmarks.find(query));
     },
 
     markMoviesWatched: function (data) {
@@ -318,7 +317,7 @@ var Database = {
     getUserInfo: function () {
         var bookmarks = Database.getAllBookmarks()
             .then(function (data) {
-                App.userBookmarks = data;
+                App.userBookmarks = extractIds(data);
             });
 
         var movies = Database.getMoviesWatched()

--- a/src/app/lib/providers/favorites.js
+++ b/src/app/lib/providers/favorites.js
@@ -8,7 +8,7 @@
     };
 
     var queryTorrents = function (filters) {
-        return App.db.getBookmarks(filters)
+        return App.db.getAllBookmarks(filters)
             .then(function (data) {
                     return data;
                 },
@@ -16,6 +16,11 @@
                     return [];
                 });
     };
+
+    var getPage = function (items, page) {
+        var byPage = 50;
+        return items.slice((page-1)*byPage,page*byPage);
+    }
 
     var sort = function (items, filters) {
         var sorted = [],
@@ -182,7 +187,8 @@
         return queryTorrents(params)
             .then(formatForButter)
             .then(function (items) {
-                return sort(items, filters);
+                items=sort(items, filters);
+                return getPage(items,filters.page);
             });
     };
 

--- a/src/app/lib/providers/favorites.js
+++ b/src/app/lib/providers/favorites.js
@@ -20,7 +20,7 @@
     var getPage = function (items, page) {
         var byPage = 50;
         return items.slice((page-1)*byPage,page*byPage);
-    }
+    };
 
     var sort = function (items, filters) {
         var sorted = [],


### PR DESCRIPTION
Favorites will now getAllBookmarks, then format and sort and then there will be returned only required page results making favorites sort order valid for all entries, loaded and non loaded favorites.
